### PR TITLE
Change HSM v1 API references to v2 in MEDS

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2022-07-06
+
+### Changed
+
+- CASMHMS-5548: Changed HSM v1 API references to v2
+
 ## [2.0.1] - 2022-05-20
 
 ### Changed

--- a/charts/v2.0/cray-hms-meds/Chart.yaml
+++ b/charts/v2.0/cray-hms-meds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-meds"
-version: 2.0.1
+version: 2.0.2
 description: "Kubernetes resources for cray-hms-meds"
 home: "https://github.com/Cray-HPE/hms-meds-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.18.0"
+appVersion: "1.19.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-meds/values.yaml
+++ b/charts/v2.0/cray-hms-meds/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.18.0
+  appVersion: 1.19.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-meds

--- a/cray-hms-meds.compatibility.yaml
+++ b/cray-hms-meds.compatibility.yaml
@@ -11,6 +11,7 @@ chartVersionToApplicationVersion:
   # Chart version: Application version
   "2.0.0": "1.17.0"
   "2.0.1": "1.18.0"
+  "2.0.2": "1.19.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Change HSM v1 API references to v2 in MEDS

## Issues and Related PRs

* Resolves [CASMHMS-5548](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5548)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable