### PR TITLE
CASMHMS-5567: Bump MEDS version

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2022-07-07
+
+### Changed
+
+- CASMHMS-5567: Allow MEDS to support variable number of Chassis within a Cabinet. Instead of always assuming 8 chassis in a cabinet MEDS will now look to SLS for the chassis present in the system.
+
 ## [2.0.2] - 2022-07-06
 
 ### Changed

--- a/charts/v2.0/cray-hms-meds/Chart.yaml
+++ b/charts/v2.0/cray-hms-meds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-meds"
-version: 2.0.2
+version: 2.0.3
 description: "Kubernetes resources for cray-hms-meds"
 home: "https://github.com/Cray-HPE/hms-meds-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.19.0"
+appVersion: "1.20.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-meds/values.yaml
+++ b/charts/v2.0/cray-hms-meds/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.19.0
+  appVersion: 1.20.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-meds

--- a/cray-hms-meds.compatibility.yaml
+++ b/cray-hms-meds.compatibility.yaml
@@ -12,6 +12,7 @@ chartVersionToApplicationVersion:
   "2.0.0": "1.17.0"
   "2.0.1": "1.18.0"
   "2.0.2": "1.19.0"
+  "2.0.3": "1.20.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Allow MEDS to support variable number of Chassis within a Cabinet. Instead of always assuming 8 chassis in a cabinet MEDS will now look to SLS for the chassis present in the system.

## Issues and Related PRs
* Resolves [CASMHMS-5567](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5567)

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable