### PR TITLE
Added github workflow to check for deprecated k8s APIs

### DIFF
--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -1,0 +1,6 @@
+name: Kubernetes API Checker
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  k8s_api_checker:
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v2
+    secrets: inherit


### PR DESCRIPTION
## Summary and Scope

Added github workflow to check for deprecated k8s APIs

## Issues and Related PRs

* Resolves [CASMHMS-5842](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5842)

## Testing

Tested on:

  * various projects with various PRs and branches

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable