### PR TITLE
CASMHMS-6361: Add pprof image support

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,14 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2025-04-04
+
+### Updated
+
+- Added support for pprof builds
+- Updated image and module dependencies
+- Updated from Go 1.23 to 1.24
+
 ## [3.1.0] - 2025-03-07
 
 ### Security

--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for pprof builds
 - Updated image and module dependencies
-- Updated from Go 1.23 to 1.24
+- Updated from Go 1.23 to 1.24 and fixed build warnings due to that
 
 ## [3.1.0] - 2025-03-07
 

--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for pprof builds
 - Updated image and module dependencies
 - Updated from Go 1.23 to 1.24 and fixed build warnings due to that
+- Internal tracking ticket: CASMHMS-6361
 
 ## [3.1.0] - 2025-03-07
 

--- a/charts/v3.1/cray-hms-meds/Chart.yaml
+++ b/charts/v3.1/cray-hms-meds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-meds"
-version: 3.1.0
+version: 3.1.1
 description: "Kubernetes resources for cray-hms-meds"
 home: "https://github.com/Cray-HPE/hms-meds-charts"
 sources:
@@ -12,6 +12,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.23.0"
+appVersion: "1.24.0"
 annotations:
+  artifacthub.io/images: |-
+    - name: cray-meds-pprof
+      image: artifactory.algol60.net/csm-docker/stable/cray-meds-pprof:1.24.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-meds/values.yaml
+++ b/charts/v3.1/cray-hms-meds/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.23.0
+  appVersion: 1.24.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-meds

--- a/cray-hms-meds.compatibility.yaml
+++ b/cray-hms-meds.compatibility.yaml
@@ -24,6 +24,7 @@ chartVersionToApplicationVersion:
   "3.0.1": "1.20.0"
   "3.0.2": "1.21.0"
   "3.1.0": "1.23.0"
+  "3.1.1": "1.24.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Added pprof image support to MEDS.

Also completed a minor update of the go module dependencies and upgraded it from Go 1.23 to 1.24.

Adopted app version 1.24.0 for CSM 1.7.0 (helm chart 3.1.1)

### Issues and Related PRs

* Resolves [CASMHMS-6361](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6361)

### Testing

Verified production image no longer contains pprof functionality.

Verified pprof image functions correctly by using a pprof client from my laptop.

Verified no apparent issues in the output logs with both the production and pprof images running.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable