### PR TITLE
CASMHMS-6395: Update module and image dependencies for scaling and resource fixes

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,15 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.2] - 2025-05-02
+
+### Updated
+
+- Updated module dependencies
+- Use hms-base for draining and closing response body
+- Fixed bug with jq use in runSnyk.sh
+- Internal tracking ticket: CASMHMS-6395
+
 ## [3.1.1] - 2025-04-04
 
 ### Updated

--- a/charts/v3.1/cray-hms-meds/Chart.yaml
+++ b/charts/v3.1/cray-hms-meds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-meds"
-version: 3.1.1
+version: 3.1.2
 description: "Kubernetes resources for cray-hms-meds"
 home: "https://github.com/Cray-HPE/hms-meds-charts"
 sources:
@@ -12,9 +12,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.24.0"
+appVersion: "1.25.0"
 annotations:
   artifacthub.io/images: |-
     - name: cray-meds-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-meds-pprof:1.24.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-meds-pprof:1.25.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-meds/values.yaml
+++ b/charts/v3.1/cray-hms-meds/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.24.0
+  appVersion: 1.25.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-meds

--- a/cray-hms-meds.compatibility.yaml
+++ b/cray-hms-meds.compatibility.yaml
@@ -25,6 +25,7 @@ chartVersionToApplicationVersion:
   "3.0.2": "1.21.0"
   "3.1.0": "1.23.0"
   "3.1.1": "1.24.0"
+  "3.1.2": "1.25.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the HMS module dependencies.

Used hms-base APIs for explicitly draining and closing http request and response bodies.

Fixed a bug with jq use when running runSnyk.sh

Adopted app version 1.25.0 for CSM 1.7.0 (helm chart 3.1.2).

### Issues and Related PRs

* Resolves [CASMHMS-6395](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6395)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched log files to ensure nothing obvious was wrong.  There were no MEDS tests to run.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable