### PR TITLE
CASMHMS-6512: Bump cray-service to latest version

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.3] - 2025-05-13
+
+### Updated
+
+- Updated cray-service dependency to the latest version
+
 ## [3.1.2] - 2025-05-02
 
 ### Updated

--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,11 +5,12 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.3] - 2025-05-13
+## [3.1.3] - 2025-05-14
 
 ### Updated
 
 - Updated cray-service dependency to the latest version
+- Internal tracking ticket: CASMHMS-6512
 
 ## [3.1.2] - 2025-05-02
 

--- a/charts/v3.1/cray-hms-meds/Chart.yaml
+++ b/charts/v3.1/cray-hms-meds/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: "cray-hms-meds"
-version: 3.1.2
+version: 3.1.3
 description: "Kubernetes resources for cray-hms-meds"
 home: "https://github.com/Cray-HPE/hms-meds-charts"
 sources:
   - "https://github.com/Cray-HPE/hms-meds"
 dependencies:
   - name: cray-service
-    version: "~11.0"
+    version: "~12.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: Hardware Management

--- a/cray-hms-meds.compatibility.yaml
+++ b/cray-hms-meds.compatibility.yaml
@@ -26,6 +26,7 @@ chartVersionToApplicationVersion:
   "3.1.0": "1.23.0"
   "3.1.1": "1.24.0"
   "3.1.2": "1.25.0"
+  "3.1.3": "1.25.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated cray-service dependency to the latest version

New helm chart version is 3.1.3 (no app version change)

### Issues and Related PRs

* Resolves [CASMHMS-6512](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6512)

### Testing

Tested on:

* `beau` (vshasta)

Test description:

- Helm upgrade of the new chart
- HMS CT tests not available for MEDS so simply compared MEDS log file with and without the changes
- Helm rollback to the prior version of the service

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable