### PR TITLE
CASMHMS-6617: Version bump-up for charts

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,13 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.5] - 2025-12-02
+
+### Updated
+
+- Updated go.mod to point to latest SMD and SLS
+- Internal tracking ticket: CASMHMS-6617
+
 ## [3.1.4] - 2025-11-24
 
 ### Updated

--- a/charts/v3.1/cray-hms-meds/Chart.yaml
+++ b/charts/v3.1/cray-hms-meds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-meds"
-version: 3.1.4
+version: 3.1.5
 description: "Kubernetes resources for cray-hms-meds"
 home: "https://github.com/Cray-HPE/hms-meds-charts"
 sources:
@@ -12,9 +12,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.26.0"
+appVersion: "1.27.0"
 annotations:
   artifacthub.io/images: |-
     - name: cray-meds-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-meds-pprof:1.26.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-meds-pprof:1.27.0
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-meds/values.yaml
+++ b/charts/v3.1/cray-hms-meds/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.26.0
+  appVersion: 1.27.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-meds

--- a/cray-hms-meds.compatibility.yaml
+++ b/cray-hms-meds.compatibility.yaml
@@ -28,6 +28,7 @@ chartVersionToApplicationVersion:
   "3.1.2": "1.25.0"
   "3.1.3": "1.25.0"
   "3.1.4": "1.26.0"
+  "3.1.5": "1.27.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

This PR focuses on updating the chart version for the hms-meds app version, as in [pull/44](https://github.com/Cray-HPE/hms-meds/pull/44) the version is updated

Adopted app version 1.27.0 for CSM 1.7.2 (helm chart 3.1.5)

## Issues and Related PRs

* Resolves [CASMHMS-6617](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6617)
* Related PR: [hms-meds](https://github.com/Cray-HPE/hms-meds/pull/44)

## Testing

Tested on:
`mug`


## Risks and Mitigations

_None_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable